### PR TITLE
Fix Event structure to handle lat/lon in response.

### DIFF
--- a/connpass.go
+++ b/connpass.go
@@ -29,8 +29,8 @@ type Event struct {
 	Etype         string  `json:"event_type"`
 	Address       string  `json:"address"`
 	Place         string  `json:"place"`
-	Lat           float64 `json:"lat"`
-	Lon           float64 `json:"lon"`
+	Lat           string  `json:"lat"`
+	Lon           string  `json:"lon"`
 	OwnerID       int     `json:"owner_id"`
 	OwnerNickname string  `json:"owner_nickname"`
 	OwnerName     string  `json:"owner_display_name"`


### PR DESCRIPTION
As of January 8 2015, "lat" and "lon" in response from connpass contain string value.
To avoid an error when json.Unmarshal in "parse" function is executed, type of "Lat" and "Lon" needs to be changed to string.
