### PR TITLE
Use https API instead of http

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![Circle CI](https://circleci.com/gh/hkurokawa/go-connpass.svg?style=shield)](https://circleci.com/gh/hkurokawa/go-connpass)
 [![Coverage Status](https://coveralls.io/repos/hkurokawa/go-connpass/badge.svg)](https://coveralls.io/r/hkurokawa/go-connpass)
 
-connpass のサーチ API (http://connpass.com/about/api/) を Go で実装したものです。
+connpass のサーチ API (https://connpass.com/about/api/) を Go で実装したものです。
 
 ## インストール
     $ go get github.com/hkurokawa/go-connpass

--- a/connpass.go
+++ b/connpass.go
@@ -1,5 +1,5 @@
 /*
-Package connpass provides a search method for using the connpass API (See http://connpass.com/about/api/).
+Package connpass provides a search method for using the connpass API (See https://connpass.com/about/api/).
 
 Construct a query, then search with that on connpass. For example:
 
@@ -48,8 +48,8 @@ import (
 	"strings"
 )
 
-// BaseUrl is the base URL of the API (See http://connpass.com/about/api/)
-const BaseUrl = "http://connpass.com/api/v1/event/"
+// BaseUrl is the base URL of the API (See https://connpass.com/about/api/)
+const BaseUrl = "https://connpass.com/api/v1/event/"
 
 // ResultSet specifies information about response and a set of returned events.
 type ResultSet struct {


### PR DESCRIPTION
Now, https is available

```
$ curl -s -I http://connpass.com/api/v1/event/
HTTP/1.1 301 Moved Permanently
Content-Length: 178
Content-Type: text/html
Date: Fri, 02 Aug 2019 02:59:29 GMT
Location: https://connpass.com/api/v1/event/
Server: nginx
Connection: keep-alive

$ curl -s -I https://connpass.com/api/v1/event/
HTTP/1.1 200 OK
Cache-Control: max-age=300
Content-Language: ja
Content-Length: 82386
Content-Type: text/json; charset=utf-8
Date: Fri, 02 Aug 2019 02:59:34 GMT
Expires: Fri, 02 Aug 2019 03:04:23 GMT
Server: nginx
Vary: Accept-Language, Cookie
X-Frame-Options: DENY
Connection: keep-alive
```


c.f. https://www.facebook.com/connpass/posts/1297721850266572
